### PR TITLE
Update everything_filter.txt

### DIFF
--- a/Chat Filters/everything_filter.txt
+++ b/Chat Filters/everything_filter.txt
@@ -249,6 +249,7 @@ your fake bot
 ^(?:[\p{L}\p{N}][\p{L}\p{N}_ -]{0,11})\s+got\s+pa\p{L}d\s+\d{1,4}\s*[kKmMbB]\b
 ^(?:[\p{L}\p{N}][\p{L}\p{N}_ -]{0,11})\s+pa\p{L}d\s+\d{1,4}\s*[kKmMbB]\b
 \d{3,4}\s*[kK]\s*or\s*\d{2,4}\s*[mM]\s+for\s+(playing|joining|participating)
-\nthe\s+person\s+[\w-]{1,12}\s+(?:put\s+\d{1,4}\s*[kKmMbB]|i\s+didn[’']?t\s+get\s+it\s+right)\b
+^the\s+person\s+[\w-]{1,12}\s+(?:put\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB]|i\s+didn[’']?t\s+get\s+it\s+right|had\s+the\s+prize\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB]|yes,?\s+i\s+accept\.?\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB])\b
+^[\w-]{1,12}\s+add[eé]d\s+\d{1,4}(?:\.\d+)?\s*[kKmMbB]\s+to\s+the\s+p[oö]t\b
 \b\d{1,3}\s*%\s+of\s+od+d[z2]s?\s+f[öo]r(?:\s+[\w-]{1,12})?\b
 \bverified\s*host\b.*\bwins?\b


### PR DESCRIPTION
Consolidate “The person <user> …” scam family; add “<user> added … to the Pot”; widen “Oddz” + “Verified Host” coverage

- Consolidated to one anchored rule for:
  - put <amount>
  - didn’t get it right
  - had the prize <amount>
  - Yes, I accept. <amount>
- New rule: <username> added <amount> to the Pot (handles diacritics, decimals).
- Kept username bounds (≤12) to avoid overmatching; supports K/M/B and decimals.
- General “Oddz för …” kept as single rule w/ optional username.
- Added robust “Verified Host … Wins” catcher.